### PR TITLE
Update rgbcw_lightbulb.yaml with Arlec 6w downlight RGB+CCT

### DIFF
--- a/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
+++ b/custom_components/tuya_local/devices/rgbcw_lightbulb.yaml
@@ -19,6 +19,10 @@ products:
   - id: gshkqhi4fx9qqwrr
     manufacturer: ANWIO
     model: BR30 RGB+CCT 13W
+  - id: 1wyg8eca64whbtcd
+    manufacturer: Arlec
+    name: Grid Connect 6w led RGB+CCT downlight
+    model_id: ALD275HA
 entities:
   - entity: light
     dps:


### PR DESCRIPTION
Addition of Arlec Grid Connect 6w led RGB+CCT downlight. Tested and working with this config. https://www.bunnings.com.au/arlec-6w-70mm-grid-connect-smart-rgb-cct-led-downlight_p0549119